### PR TITLE
feat: add selenized theme

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -228,6 +228,8 @@ fn add_themes(b: *std.Build, exe: anytype) void {
         .{ "base16", "themes/woodland-dark.json" },
         .{ "alabaster", "theme/alabaster-color-theme.json" },
         .{ "ethereal", "themes/ethereal-color-theme.json" },
+        .{ "selenized", "editors/visual-studio-code/themes/selenized-dark.json" },
+        .{ "selenized", "editors/visual-studio-code/themes/selenized-light.json" },
     };
     inline for (theme_list) |list| {
         theme_file(b, exe, list[0], list[1]);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -99,6 +99,10 @@
             .url = "git+https://github.com/bjarneo/ethereal-vscode.git?ref=main#056e596b48f13306b366b8ca7a70326a924a9cff",
             .hash = "N-V-__8AAHRcEwAAvSM_ODzsp-La1PE4Ydrg8MR827anf94J",
         },
+        .theme_selenized = .{
+            .url = "git+https://github.com/jan-warchol/selenized?ref=master#9a753d5c575c48e29eeb2be745d9571b4cec42b3",
+            .hash = "N-V-__8AAFxeDgAAAxUwDQG7UYFdbTtDN_V7uCgmycPJNr0G",
+        },
         .cbor = .{
             .url = "git+https://github.com/neurocyte/cbor?ref=master#7d2eeb68c8a2fb3f4d6baad6cc04c521b92974c0",
             .hash = "cbor-1.0.0-RcQE_AswAQAPlqBCZXYQf9DZXn-0Ubt8Mk03ZcJWcsAG",

--- a/src/theme_files.zig
+++ b/src/theme_files.zig
@@ -50,6 +50,7 @@ pub const theme_files = [_]theme_file{
     THEME("themes/kanagawa-wave-color-theme.json"),
     THEME("themes/kanagawa-dragon-color-theme.json"),
     THEME("themes/ethereal-color-theme.json"),
+    THEME("editors/visual-studio-code/themes/selenized-dark.json"),
 
     // base16 collection dark
 
@@ -150,6 +151,7 @@ pub const theme_files = [_]theme_file{
     THEME("themes/latte.json"),
     THEME("themes/kanagawa-lotus-color-theme.json"),
     THEME("theme/alabaster-color-theme.json"),
+    THEME("editors/visual-studio-code/themes/selenized-light.json"),
 
     // base16 collection light
 


### PR DESCRIPTION
[Selenized](https://github.com/jan-warchol/selenized) is an improved version of Solarized with some tweaks for better contrast and terminal colors. I started using it for my terminal emulator (Ghostty has it built-in), and I thought it would be nice to use in Flow as well, for consistency.

I've been using this locally for about a week now (at least the light theme), and it's been working well for me.