### PR TITLE
Kanso Theme for Flow.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -230,6 +230,10 @@ fn add_themes(b: *std.Build, exe: anytype) void {
         .{ "ethereal", "themes/ethereal-color-theme.json" },
         .{ "selenized", "editors/visual-studio-code/themes/selenized-dark.json" },
         .{ "selenized", "editors/visual-studio-code/themes/selenized-light.json" },
+        .{ "kanso", "themes/kanso-zen.json" },
+        .{ "kanso", "themes/kanso-ink.json" },
+        .{ "kanso", "themes/kanso-mist.json" },
+        .{ "kanso", "themes/kanso-pearl.json" },
     };
     inline for (theme_list) |list| {
         theme_file(b, exe, list[0], list[1]);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -103,6 +103,10 @@
             .url = "git+https://github.com/jan-warchol/selenized?ref=master#9a753d5c575c48e29eeb2be745d9571b4cec42b3",
             .hash = "N-V-__8AAFxeDgAAAxUwDQG7UYFdbTtDN_V7uCgmycPJNr0G",
         },
+        .theme_kanso = .{
+            .url = "git+https://github.com/AstralisU/kanso-vscode?ref=main#643b4e46e54277969417049775fc824cd6292e8b",
+            .hash = "N-V-__8AAA72RgCvA8bQFrVG96f_wvRoajiIsDZtV_75BGgI",
+        },
         .cbor = .{
             .url = "git+https://github.com/neurocyte/cbor?ref=master#7d2eeb68c8a2fb3f4d6baad6cc04c521b92974c0",
             .hash = "cbor-1.0.0-RcQE_AswAQAPlqBCZXYQf9DZXn-0Ubt8Mk03ZcJWcsAG",

--- a/src/theme_files.zig
+++ b/src/theme_files.zig
@@ -50,6 +50,9 @@ pub const theme_files = [_]theme_file{
     THEME("themes/kanagawa-wave-color-theme.json"),
     THEME("themes/kanagawa-dragon-color-theme.json"),
     THEME("themes/ethereal-color-theme.json"),
+    THEME("themes/kanso-zen.json"),
+    THEME("themes/kanso-ink.json"),
+    THEME("themes/kanso-mist.json"),
     THEME("editors/visual-studio-code/themes/selenized-dark.json"),
 
     // base16 collection dark
@@ -152,6 +155,7 @@ pub const theme_files = [_]theme_file{
     THEME("themes/kanagawa-lotus-color-theme.json"),
     THEME("theme/alabaster-color-theme.json"),
     THEME("editors/visual-studio-code/themes/selenized-light.json"),
+    THEME("themes/kanso-pearl.json"),
 
     // base16 collection light
 


### PR DESCRIPTION
I like this theme and i started to use Flow as my main Editor so i decided to add it to the flow-theme repo 

here how it looks 

Kanso-zen 
<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/ccedf9c6-128c-4126-a3ae-c83e25c7026e" />

Kanso-Ink 
<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/d86a6480-93c5-44ec-b8fc-2df12875f946" />

Kanso-Mist
<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/09b11236-822f-4a86-9a61-4febc75f7ca5" />

Kanso-Pearl
<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/a3a9f709-c0c8-4972-a70a-971a132803f9" />

Kanso-zen with the Command opened 
<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/6be1c8b5-ca57-4ee1-b381-c75d6f59e7bb" />

Kanso-zen with the find files 
<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/2bcfc5fb-b9d4-4cc4-b026-c3df764fd044" />


